### PR TITLE
Sync Shipwire environment test helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ language: ruby
 rvm:
   - 2.3.1
 env:
+  global:
+    - BUNDLE_SPECIFIC_PLATFORM="true bundle"
   matrix:
     - SOLIDUS_BRANCH=v1.0 DB=postgres
     - SOLIDUS_BRANCH=v1.1 DB=postgres

--- a/lib/spree/testing_support/shipwire_factory.rb
+++ b/lib/spree/testing_support/shipwire_factory.rb
@@ -1,0 +1,17 @@
+require 'retriable'
+
+require_relative 'shipwire_factory/product'
+require_relative 'shipwire_factory/warehouse'
+
+module ShipwireFactory
+  class MissingOnShipwire < StandardError; end
+  class CreationErrorOnShipwire < StandardError; end
+
+  def sw_product_factory
+    ShipwireFactory::Product.new
+  end
+
+  def sw_warehouse_factory
+    ShipwireFactory::Warehouse.new
+  end
+end

--- a/lib/spree/testing_support/shipwire_factory/product.rb
+++ b/lib/spree/testing_support/shipwire_factory/product.rb
@@ -1,0 +1,65 @@
+module ShipwireFactory
+  class Product
+    def create_product_in_stock(params)
+      product_json = default_product_json.merge params
+
+      shipwire_product = Shipwire::Products.new.create(product_json)
+      raise CreationErrorOnShipwire, shipwire_product.error_report unless shipwire_product.ok?
+
+      Shipwire::Stock.new.adjust(
+        sku: shipwire_product.body['resource']['items'].first['resource']['sku'],
+        quantity: 50,
+        warehouseId: warehouse['id'],
+        reason: 'Init for test'
+      )
+
+      shipwire_product
+    end
+
+    def in_stock(params = {})
+      search_params = { sku: 'product-in-stock', classification: 'baseProduct',
+                        status: 'instock', limit: 1 }.merge params
+
+      Retriable.retriable on: { MissingOnShipwire => nil },
+                          on_retry: proc{ create_product_in_stock(search_params) } do
+
+        shipwire_response = Shipwire::Products.new.list(search_params)
+
+        products = shipwire_response.body['resource']['items']
+
+        raise MissingOnShipwire if products.empty?
+
+        products.first['resource']
+      end
+    end
+
+    private
+
+    def default_product_json
+      {
+        sku: "test-sku",
+        classification: 'baseProduct',
+        description: 'description',
+        countryOfOrigin: "US",
+        category: "FURNITURE_&_APPLIANCES",
+        batteryConfiguration: 'NOBATTERY',
+        values: {
+          costValue: 10,
+          retailValue: 10,
+          costCurrency: "USD",
+          retailCurrency: "USD"
+        },
+        dimensions: {
+          length: 1,
+          width: 10,
+          height: 1,
+          weight: 1
+        }
+      }
+    end
+
+    def warehouse
+      ShipwireFactory::Warehouse.new.default
+    end
+  end
+end

--- a/lib/spree/testing_support/shipwire_factory/warehouse.rb
+++ b/lib/spree/testing_support/shipwire_factory/warehouse.rb
@@ -1,0 +1,9 @@
+module ShipwireFactory
+  class Warehouse
+    def default
+      Shipwire::Warehouses.new.list(type: 'SHIPWIRE_ANYWHERE').body['resource']['items'].first['resource']
+    rescue NoMethodError
+      raise 'No warehouse of type SHIPWIRE_ANYWHERE on shipwire'
+    end
+  end
+end

--- a/solidus_shipwire.gemspec
+++ b/solidus_shipwire.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 3.0'
   s.add_development_dependency 'webmock', '~> 2.1'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'retriable'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ Dir[Rails.root.join('spec/support/shared_examples/**/*.rb')].each { |f| require 
 # Requires factories defined in spree_core
 require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
+require 'spree/testing_support/shipwire_factory'
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
@@ -30,6 +31,8 @@ RSpec.configure do |config|
   # visit spree.admin_path
   # current_path.should eql(spree.products_path)
   config.include Spree::TestingSupport::UrlHelpers
+
+  config.include ShipwireFactory
 
   # == Mock Framework
   #
@@ -48,4 +51,3 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 end
-


### PR DESCRIPTION
To test shipwire object is required that product exists on shipwire.
With this hack the helper search and extracts the object from shipwire,
if it's missing tries to create it.