### PR TITLE
Remove shipwire tab and info on order index and show page

### DIFF
--- a/app/overrides/spree/admin/orders/index/add_shipwire_info_td.html.erb.deface
+++ b/app/overrides/spree/admin/orders/index/add_shipwire_info_td.html.erb.deface
@@ -1,5 +1,0 @@
-<!-- insert_before '[data-hook=admin_orders_index_row_actions]' -->
-<td>
-  <span class="state <%= order.shipwire_id.present? ? 'success' : 'error' %>">
-  <%= order.shipwire_id.present? ? t('shipwire.synced') : t('shipwire.not_synced') %>
-</td>

--- a/app/overrides/spree/admin/orders/index/add_shipwire_info_th.html.erb.deface
+++ b/app/overrides/spree/admin/orders/index/add_shipwire_info_th.html.erb.deface
@@ -1,2 +1,0 @@
-<!-- insert_before '[data-hook=admin_orders_index_header_actions]' -->
-<th><%= t 'shipwire.name' %></th>

--- a/app/overrides/spree/admin/shared/_order_submenu/add_shipwire_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_submenu/add_shipwire_tab.html.erb.deface
@@ -1,6 +1,0 @@
-<!-- insert_bottom '[data-hook=admin_order_tabs]' -->
-<% if @order.complete? %>
-  <li class="tab <%= "active" if current == "Shipwire" %>" data-hook='admin_order_tabs_shipwire'>
-    <%= link_to_with_icon 'share', t('shipwire.name'), shipwire_admin_order_url(@order) %>
-  </li>
-<% end %>

--- a/app/overrides/spree/admin/shared/_order_summary/add_shipwire_sync_button.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_summary/add_shipwire_sync_button.html.erb.deface
@@ -1,9 +1,0 @@
-<!-- insert_bottom '#order_tab_summary > dl' -->
-<% if @order.complete? %>
-  <dt><%= Spree::Order.human_attribute_name(:shipwire_id) %></dt>
-  <% if @order.shipwire_id.nil? %>
-    <dd>not sync</td>
-  <% else %>
-    <dd><%= @order.shipwire_id %></td>
-  <% end %>
-<% end %>


### PR DESCRIPTION
This PR removes the shipwire tab and sync info from admin order show page. It also removes the shipwire sync info from the admin order index page. 

It makes no sense anymore since shipwire is on shipment now, not on order.