### PR TITLE
Clear the shipwire_id field even if the cancel API throws an error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,17 @@ source 'https://rubygems.org'
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
-if branch == 'master' || branch >= 'v2.0'
-  gem 'rails-controller-testing', group: :test
-else
-  gem 'rails_test_params_backport', group: :test
+group :test do
+  if branch == 'master' || branch >= 'v2.0'
+    gem 'rails-controller-testing'
+  else
+    gem 'rails_test_params_backport'
+  end
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
 end
 
 group :development, :test do

--- a/lib/solidus_shipwire/shipwireable/shipwire_api.rb
+++ b/lib/solidus_shipwire/shipwireable/shipwire_api.rb
@@ -143,7 +143,7 @@ module SolidusShipwire
           return if shipwire_id.blank?
 
           response = self.class.cancel_from_shipwire(shipwire_id)
-          update_attribute(:shipwire_id, nil) if response.ok?
+          update_attribute(:shipwire_id, nil)
 
           response
         end

--- a/solidus_shipwire.gemspec
+++ b/solidus_shipwire.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'solidus_support'
   s.add_runtime_dependency 'retriable'
 
-  s.add_development_dependency 'factory_bot', '~> 4.4'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails', '~> 3.0'
   s.add_development_dependency 'vcr', '~> 3.0'


### PR DESCRIPTION
Previously the `shipwire_id` wasn't cleared if the cancel API threw an error. This caused an issue when the related shipwire entity was already deleted but the shipwire_id was still present because in this scenario the API returns a `422 - Order cannot be cancelled`.