### PR TITLE
Don't create the CRUD routes for shipments

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Spree::Core::Engine.routes.draw do
   namespace :api, defaults: { format: 'json' } do
-    resources :shipments do
+    resources :shipments, only: [] do
       resources :rates, only: [:index], module: :shipwire
     end
   end


### PR DESCRIPTION
There is no need to create all the CRUD routes for shipments, the `solidus_api` gem adds [only the `create` and the `update` routes](https://github.com/solidusio/solidus/blob/master/api/config/routes.rb#L79-L84).
Adding also the `show` leads to a conflict with the `mine` route because in the url `api/shipments/mine`, the `mine` part is treated as the `id` of the shipment for the `show` action and not as a standalone route.
```ruby
api_shipment       GET    /api/shipments/:id(.:format)                                                                       spree/api/shipments#show {:format=>"json"}
mine_api_shipments GET    /api/shipments/mine(.:format)                                                                      spree/api/shipments#mine {:format=>"json"}
```