### PR TITLE
Services like MySQL or PostgreSQL are not started by default in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ branches:
 language: ruby
 rvm:
   - 2.5.0
+services:
+  - mysql
+  - postgresql
 env:
   global:
     - BUNDLE_SPECIFIC_PLATFORM="true bundle"


### PR DESCRIPTION
As of August, 13th 2019, Travis CI has switched the default Linux distribution from Ubuntu Trusty 14.04 LTS to Ubuntu Xenial 16.04. 

Services like MySQL or PostgreSQL are not started by default. To start any service, such as MySQL, add it to the services key in your config:
```yaml
  services:
    - mysql
```
Source: https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide/